### PR TITLE
Upgrade block content renderer to new API

### DIFF
--- a/frontend/components/LongformArticle.js
+++ b/frontend/components/LongformArticle.js
@@ -1,100 +1,90 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import BlockContent from '@sanity/block-content-to-react';
 import slugify from 'slugify';
 
 import { PullQuote, Figure } from './';
-import randomKey from '../helpers/randomKey';
 
 /**
  * Here we replace Sanity's react components for rendering basic things like
  * lists so that we can drop in our classnames
  * @type {Object}
  */
-const blockTypeHandlersOverride = {
-  listBlock: {
-    number: ({ children = [] }) => (
-      <ol key={randomKey()} className="list-numbered c-longform-grid__standard ">
+const serializers = {
+  types: {
+    image: ({ node }) => <Figure {...node} />,
+    pullQuote: ({ node: { text } }) => (
+      <div className="c-longform-grid__medium">
+        <PullQuote>{text}</PullQuote>
+      </div>
+    ),
+    nugget: ({ node: { text, title } }) => (
+      <div className="c-article__nugget c-longform-grid__standard">
+        <h2 className="c-article__nugget-title">{title}</h2>
+        <BlockContent blocks={text} />
+      </div>
+    ),
+    block: ({ node, children }) => {
+      const style = node.style || 'normal';
+
+      // Heading?
+      if (/^h\d/.test(style)) {
+        const level = parseInt(style.slice(1), 10);
+        const id = level === 2 || level === 3
+          ? slugify(children[0], { lower: true })
+          : undefined;
+
+        return React.createElement(
+          style,
+          { id, className: 'c-longform-grid__standard' },
+          children,
+        );
+      }
+
+      if (style === 'blockquote') {
+        return (
+          <blockquote className="c-longform-grid__large-right">
+            {children}
+          </blockquote>
+        );
+      }
+
+      return (
+        <p className="c-longform-grid__standard ">
+          {children}
+        </p>
+      );
+    },
+  },
+
+  list: ({ type, children }) => {
+    if (type === 'bullet') {
+      return (
+        <ul className="list-bullets c-longform-grid__standard ">
+          {children}
+        </ul>
+      );
+    }
+
+    return (
+      <ol className="list-numbered c-longform-grid__standard ">
         {children}
       </ol>
-    ),
-    bullet: ({ children = [] }) => (
-      <ul key={randomKey()} className="list-bullets c-longform-grid__standard ">
-        {children}
-      </ul>
-    ),
-    listItem: ({ children = [] }) => <li key={randomKey()}>{children}</li>,
-  },
-  textBlock: {
-    normal: ({ children = [] }) => (
-      <p key={randomKey()} className="c-longform-grid__standard ">
-        {children}
-      </p>
-    ),
-    h1: ({ children = [] }) => (
-      <h1
-        key={randomKey()}
-        className="c-longform-grid__standard "
-      >
-        {children}
-      </h1>
-    ),
-    h2: ({ children = [] }) => (
-      <h2
-        key={randomKey()}
-        id={slugify(children[0], { lower: true })}
-        className="c-longform-grid__standard"
-      >
-        {children}
-      </h2>
-    ),
-    h3: ({ children = [] }) => (
-      <h3
-        key={randomKey()}
-        id={slugify(children[0], { lower: true })}
-        className="c-longform-grid__standard"
-      >
-        {children}
-      </h3>
-    ),
-    h4: ({ children = [] }) => (
-      <h4 key={randomKey()} className="c-longform-grid__standard ">
-        {children}
-      </h4>
-    ),
-    blockquote: ({ children = [] }) => (
-      <blockquote key={randomKey()} className="c-longform-grid__large-right">
-        {children}
-      </blockquote>
-    ),
+    );
   },
 };
 
-const customTypeHandlers = {
-  image: ({ attributes }) => <Figure key={randomKey()} {...attributes} />,
-  pullQuote: ({ attributes: { text } }) => (
-    <div key={randomKey()} className="c-longform-grid__medium">
-      <PullQuote>{text}</PullQuote>
-    </div>
-  ),
-  nugget: ({ attributes: { text, title } }) => (
-    <div key={randomKey()} className="c-article__nugget c-longform-grid__standard">
-      <h2 className="c-article__nugget-title">{title}</h2>
-      <BlockContent blocks={text} />
-    </div>
-  ),
-};
-
-class LongformArticle extends Component {
+class LongformArticle extends Component {
   render() {
     const { content = [] } = this.props;
+    const blocks = content.filter(block => !['reference'].includes(block._type));
     return (
-      <main className=" c-article c-longform-grid-sub-div">
-        <BlockContent
-          blocks={content.filter(block => !['reference'].includes(block._type))}
-          blockTypeHandlers={{ ...blockTypeHandlersOverride }}
-          customTypeHandlers={customTypeHandlers}
-        />
+      <main className="c-article c-longform-grid-sub-div">
+        {blocks.length > 0 && (
+          <BlockContent
+            blocks={blocks}
+            serializers={serializers}
+          />
+        )}
       </main>
     );
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Monorepo for u4.no",
   "main": "index.js",
   "dependencies": {
-    "@sanity/block-content-to-react": "^0.3.0",
+    "@sanity/block-content-to-react": "^1.0.1",
     "@sanity/block-content-to-tree": "^0.3.0",
     "@sanity/client": "^0.113.0",
     "@storybook/react": "^3.2.8",


### PR DESCRIPTION
This upgrades the Sanity block content renderer to the new API.
I discovered a couple of issues in the renderer module while upgrading:

- Empty arrays of blocks are not handled properly, easy fix
- There are a couple of cases where certain blocks and spans do not have a key, I'll address this too - ignore missing key warnings for now

