### PR TITLE
Add padding on mobile publication reader, blog and article

### DIFF
--- a/frontend/components/article/ArticleContainer.js
+++ b/frontend/components/article/ArticleContainer.js
@@ -126,7 +126,7 @@ const ArticleContainer = (props = {}) => {
         <hr className="u-section-underline--no-margins" />
 
         <section
-          className="o-wrapper-medium o-wrapper-mobile-full"
+          className="o-wrapper-medium "
           style={{ display: readerOpen ? 'none' : 'block' }}
         >
           {content.length > 0 && (

--- a/frontend/components/publication/Reader.js
+++ b/frontend/components/publication/Reader.js
@@ -49,7 +49,7 @@ export const Reader = ({ data, setReaderOpen = false, legacypdf = {}, shortversi
       <span id="js-top-reader" />
       <TitleProgressSpy content={content} />
       <ReaderHeader data={data} setReaderOpen={setReaderOpen} targetRef={readerRef} />
-      <section className="o-wrapper-medium o-wrapper-mobile-full">
+      <section className="o-wrapper-medium">
         {content.length > 0 && (
           <main className="c-reader__main o-wrapper-section c-article__row">
             <div className="c-article__content c-article__col">

--- a/frontend/pages/blog/[slug].js
+++ b/frontend/pages/blog/[slug].js
@@ -61,7 +61,7 @@ const BlogEntry = ({ data: { blogEntry = {} }, url = {} }) => {
           <ArticleHeader data={blogEntry} />
         </section>
         <hr className="u-section-underline--no-margins" />
-        <section className="o-wrapper-medium o-wrapper-mobile-full">
+        <section className="o-wrapper-medium ">
           <div className="c-article__row">
             <div className="content c-article__col">
               <div className="u-margin--article-top">

--- a/frontend/style/components/publication/_publication-entry.scss
+++ b/frontend/style/components/publication/_publication-entry.scss
@@ -28,10 +28,13 @@
 
 .c-article__row {
   width: 100%;
-  display: inline-grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: auto;
+  // robert removed 09.02.2022 trying to regain padding on mobile
+  //display: inline-grid;
+  //grid-template-columns: 1fr;
+  //grid-template-rows: auto;
   @include mq($from: desktop) {
+    display: inline-grid;
+    grid-template-rows: auto;
     grid-template-columns: 5fr 2fr;
     column-gap: 20px;
   }


### PR DESCRIPTION
(Removed the class o-wrapper-mobile-full from top element) and removed display:inline-grid on mobile
